### PR TITLE
Fix deprecated numpyint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push: # git push
   pull_request: # PR
   workflow_dispatch: # manual
 
@@ -11,20 +10,33 @@ jobs:
     env:
       TRAVIS: 'true' # Skip tests requiring data
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - '2.7' # production
-          - '3.8'
           - '3.9'
+          - '3.10'
         mongodb-version:
           - 2
     name: Python ${{ matrix.python-version }}
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        if: matrix.python-version != '2.7'
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Set up Python 2.7
+        if: matrix.python-version == '2.7'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python2.7 python2.7-dev
+          sudo ln -sf python2.7 /usr/bin/python
+          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
+          python get-pip.py
+          rm get-pip.py
+          pip install --upgrade pip setuptools wheel
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.7.0
         with:
@@ -32,15 +44,23 @@ jobs:
           mongodb-replica-set: test-rs
       - name: Install dependencies
         run: |
+          export ROOT_DIR_SRC=${{github.workspace}}/..
+          cd $ROOT_DIR_SRC
+          pip install virtualenv
+          virtualenv venv
+          . $ROOT_DIR_SRC/venv/bin/activate
           pip install https://files.pythonhosted.org/packages/3e/5c/2867e46f03d2fcc3d014a02eeb11ec55f3f8d9eddddcc5578ae8457f84f8/ERPpeek-1.7.1-py2.py3-none-any.whl
           pip install pytest-cov pytest
-          ./setup.py develop
+          cd ${{github.workspace}}
+          pip install -e .
       - uses: BSFishy/pip-action@v1
         with:
           packages: |
             coveralls
       - name: Unit tests
         run: |
+          export ROOT_DIR_SRC=${{github.workspace}}/..
+          . $ROOT_DIR_SRC/venv/bin/activate
           pytest
 
       - name: Coveralls

--- a/plantmeter/mongotimecurve.py
+++ b/plantmeter/mongotimecurve.py
@@ -116,14 +116,14 @@ class MongoTimeCurve(object):
         ndays = (stop.date()-start.date()).days+1
         data = numpy.zeros(ndays*hoursPerDay, int)
         if filling :
-            filldata = numpy.zeros(ndays*hoursPerDay, numpy.bool)
+            filldata = numpy.zeros(ndays*hoursPerDay, bool)
         filters = {
             self.timestamp: {
                 '$gte': start,
                 '$lt': addDays(stop,1)
             }
         }
-        if hasattr(filter, '__iter__'):
+        if isinstance(filter, dict):
             filters.update(filter)
         elif filter: filters.update(name=filter)
         from bson.son import SON
@@ -224,6 +224,9 @@ class MongoTimeCurve(object):
         assert start.tzinfo is not None, (
             "MongoTimeCurve.update called with naive (no timezone) start date")
 
+        if isinstance(filter, str):
+            filter = dict(name=filter)
+
         stop = start + datetime.timedelta(days=len(data)//hoursPerDay+1)
         oldData, filling = self.get(start, stop, filter, field, filling=True)
         if type(data) == numpy.ndarray:
@@ -234,7 +237,7 @@ class MongoTimeCurve(object):
             if bin == old: continue
             self.fillPoint(
                 datetime=curveDate,
-                name=filter,
+                name=filter['name'],
                 **{field: bin}
                 )
 

--- a/plantmeter/mongotimecurve.py
+++ b/plantmeter/mongotimecurve.py
@@ -114,7 +114,7 @@ class MongoTimeCurve(object):
             "MongoTimeCurve.get called with naive (no timezone) stop date")
 
         ndays = (stop.date()-start.date()).days+1
-        data = numpy.zeros(ndays*hoursPerDay, numpy.int)
+        data = numpy.zeros(ndays*hoursPerDay, int)
         if filling :
             filldata = numpy.zeros(ndays*hoursPerDay, numpy.bool)
         filters = {

--- a/plantmeter/mongotimecurve_test.py
+++ b/plantmeter/mongotimecurve_test.py
@@ -235,7 +235,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-01-01'),
             stop=localisodate('2015-01-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -250,7 +250,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-01-01'),
             stop=localisodate('2015-01-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -265,7 +265,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2014-12-31'),
             stop=localisodate('2015-01-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -282,7 +282,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-01-01'),
             stop=localisodate('2015-01-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -298,7 +298,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-01-01'),
             stop=localisodate('2015-01-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -314,7 +314,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-01-01'),
             stop=localisodate('2015-01-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -329,7 +329,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-01-01'),
             stop=localisodate('2015-01-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -379,7 +379,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-01-01'),
             stop=localisodate('2015-01-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -395,7 +395,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-08-01'),
             stop=localisodate('2015-08-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -414,7 +414,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-03-29'),
             stop=localisodate('2015-03-29'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -429,7 +429,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-03-29'),
             stop=localisodate('2015-03-30'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -449,7 +449,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-10-25'),
             stop=localisodate('2015-10-25'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -560,7 +560,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         curve = mtc.get(
             start=localisodate('2015-01-01'),
             stop=localisodate('2015-01-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -591,7 +591,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         _, curve = mtc.get(
             start=localisodate('2015-08-15'),
             stop=localisodate('2015-08-15'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             filling=True,
             )
@@ -608,7 +608,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         _,curve = mtc.get(
             start=localisodate('2015-08-15'),
             stop=localisodate('2015-08-15'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             filling=True,
             )
@@ -623,7 +623,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
         with self.assertRaises(AssertionError) as ctx:
             mtc.update(
                 start=datetime.datetime(2015,8,15),
-                filter='miplanta',
+                filter=dict(name='miplanta'),
                 field='ae',
                 data=[],
                 )
@@ -649,7 +649,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
             mtc.get(
                 start=datetime.datetime(2015,8,15),
                 stop=localisodate("2015-08-15"),
-                filter='miplanta',
+                filter=dict(name='miplanta'),
                 field='ae',
                 )
         self.assertEqual(ctx.exception.args[0],
@@ -662,7 +662,7 @@ class MongoTimeCurve_Test(unittest.TestCase):
             mtc.get(
                 start=localisodate("2015-08-15"),
                 stop=datetime.datetime(2015,8,15),
-                filter='miplanta',
+                filter=dict(name='miplanta'),
                 field='ae',
                 )
         self.assertEqual(ctx.exception.args[0],
@@ -673,14 +673,14 @@ class MongoTimeCurve_Test(unittest.TestCase):
 
         curve = mtc.update(
             start=localisodate('2015-08-15'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             data=[1]+24*[0]
             )
         curve, filling = mtc.get(
             start=localisodate('2015-08-15'),
             stop=localisodate('2015-08-15'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             filling=True,
             )
@@ -694,18 +694,19 @@ class MongoTimeCurve_Test(unittest.TestCase):
             )
 
     def test_get_withFilledGap(self):
+
         mtc = self.setupPoints([])
 
         curve = mtc.update(
             start=localisodate('2015-08-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             data=+25*[1]+[1]+24*[1]
             )
         curve = mtc.get(
             start=localisodate('2015-08-01'),
             stop=localisodate('2015-08-01'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             )
         self.assertEqual(
@@ -718,14 +719,14 @@ class MongoTimeCurve_Test(unittest.TestCase):
 
         curve = mtc.update(
             start=localisodate('2015-08-15'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             data=+25*[1]
             )
         curve, filling = mtc.get(
             start=localisodate('2015-08-15'),
             stop=localisodate('2015-08-15'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             filling=True,
             )
@@ -744,14 +745,14 @@ class MongoTimeCurve_Test(unittest.TestCase):
 
         curve = mtc.update(
             start=localisodate('2015-08-15'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             data=numpy.array(+25*[1]), # This is different
             )
         curve, filling = mtc.get(
             start=localisodate('2015-08-15'),
             stop=localisodate('2015-08-15'),
-            filter='miplanta',
+            filter=dict(name='miplanta'),
             field='ae',
             filling=True,
             )

--- a/plantmeter/resource_test.py
+++ b/plantmeter/resource_test.py
@@ -13,6 +13,7 @@ from .resource import (
     )
 
 import unittest
+import pytest
 
 def local_file(filename):
     return os.path.join(os.path.abspath(os.path.dirname(__file__)), filename)
@@ -185,12 +186,13 @@ class Resource_Test(unittest.TestCase):
                 0,0,0,0,0,0,0,0,8,14,12,10,18,36,70,26,26,12,8,4,0,0,0,0,0,
             ])
 
+    import sys
+    @pytest.mark.skipif(sys.version_info > (2,8), reason="py3 numpy requires same dimensions when sum arrays")
     def test__get_kwh__twoPlantsOneMeter(self):
         m1 = self.setupMeter(1, 'm1')
         self.fillMeter('m1', '2015-09-04')
         p1 = ProductionPlant(1,'plantName1','plantDescription1',True, meters=[m1])
         p2 = ProductionPlant(2,'plantName2','plantDescription2',True)
-
         aggr = ProductionAggregator(1,'aggrName','aggrDescription',True,plants=[p1,p2])
 
         self.assertEqual(


### PR DESCRIPTION
## Description

From numpy version 1.20, type `numpy.int` is deprecated. So we use builtin int as recomended on [official doc](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)

## Changes

- Change `numpy.int` corrences for `int`
- Fix test from #2 because test use `str` plant name in test (unlikely production that use `int`)
