### PR TITLE
✅ Change pymongo version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 somutils==1.7.2
-pymongo<3.0;python_version<="2.7.18"
+pymongo==3.13.0;python_version<="2.7.18"
 pymongo<4.0;python_version>"2.7.18"
 numpy<1.17;python_version<="2.7.18"
 numpy;python_version>"2.7.18"


### PR DESCRIPTION
## Description

[mongodb_backend](https://github.com/gisce/mongodb_backend/pull/39) requires pymongo==3.13.0 and reinstalling pymongo cause [bson](https://github.com/py-bson/bson/issues/82) python package error
[more info](https://stackoverflow.com/questions/12983472/import-pymongo-causes-importerror-cannot-import-name-bson-how-do-you-fix-the)

Uninstalling pymongo 2.9.5 and installing pymongo 3.13.0

```
Collecting pymongo==3.13.0
  Using cached pymongo-3.13.0-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl (502 kB)
Requirement already satisfied: six in /home/runner/work/openerp_som_addons/venv/lib/python2.7/site-packages (from -r /home/runner/work/openerp_som_addons/erp/server/bin/addons/mongodb_backend/requirements.txt (line 3)) (1.16.0)
Installing collected packages: pymongo
  Attempting uninstall: pymongo
    Found existing installation: pymongo 2.9.5
    Uninstalling pymongo-2.9.5:
      Successfully uninstalled pymongo-2.9.5
ERROR: pip's legacy dependency resolver does not consider dependency conflicts when selecting packages. This behaviour is the source of the following dependency conflicts.
plantmeter 1.7.8 requires pymongo<3.0, but you'll have pymongo 3.13.0 which is incompatible.
Successfully installed pymongo-3.13.0
```

Error when loading bson package
```
2024-02-07 07:23:28,781:CRITICAL:openerp.init:[01]: 
2024-02-07 07:23:28,781:CRITICAL:openerp.init:[02]: Environment Information : 
2024-02-07 07:23:28,781:CRITICAL:openerp.init:[03]: System : Linux-6.2.0-1019-azure-x86_64-with-Ubuntu-22.04-jammy
2024-02-07 07:23:28,781:CRITICAL:openerp.init:[04]: OS Name : posix
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[05]: Distributor ID:	Ubuntu
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[06]: Description:	Ubuntu 22.04.3 LTS
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[07]: Release:	22.04
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[08]: Codename:	jammy
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[09]: Operating System Release : 6.2.0-1019-azure
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[10]: Operating System Version : #19~22.04.1-Ubuntu SMP Wed Jan 10 22:57:03 UTC 2024
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[11]: Operating System Architecture : 64bit
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[12]: Operating System Locale : en_US.UTF-8
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[13]: Python Version : 2.7.18
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[14]: OpenERP-Server Version : 5.0.14
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[15]: Git revision description: 
2024-02-07 07:23:28,782:CRITICAL:openerp.init:[16]: cannot import name abc
Update progress:   3%|▎         | 3/113 [00:02<01:32,  1.19it/s]
Traceback (most recent call last):
  File "/home/runner/work/openerp_som_addons/erp/server/bin/addons/__init__.py", line 958, in load_modules
    r = load_module_graph(cr, graph, status, report=report)
  File "/home/runner/work/openerp_som_addons/erp/server/bin/addons/__init__.py", line 780, in load_module_graph
    register_class(package.name)
  File "/home/runner/work/openerp_som_addons/erp/server/bin/addons/__init__.py", line 449, in register_class
    imp.load_module(m, *fm)
  File "/home/runner/work/openerp_som_addons/erp/server/bin/addons/mongodb_backend/__init__.py", line 3, in <module>
    from . import orm_mongodb
  File "/home/runner/work/openerp_som_addons/erp/server/bin/addons/mongodb_backend/orm_mongodb.py", line 28, in <module>
    import gridfs
  File "/home/runner/work/openerp_som_addons/venv/lib/python2.7/site-packages/gridfs/__init__.py", line 23, in <module>
    from bson.py3compat import abc
ImportError: cannot import name abc
```


