### PR TITLE
Fix som_plantmeter tests

### DIFF
--- a/.github/workflows/som_plantmeter.yml
+++ b/.github/workflows/som_plantmeter.yml
@@ -1,0 +1,16 @@
+# This workflow will pass tests of module passed by input
+
+name: som_plantmeter
+on:
+  workflow_dispatch:
+  pull_request: # PR
+jobs:
+  erp-tests-module:
+    uses: Som-Energia/openerp_som_addons/.github/workflows/reusable_workflow.yml@main
+    with:
+      module: som_plantmeter
+    secrets:
+      ACCESS_TOKEN_GA: ${{ secrets.ACCESS_TOKEN_GA }}
+      ESIOS_TOKEN: ${{ secrets.ESIOS_TOKEN }}
+      SRID: ${{ secrets.SRID }}
+

--- a/plantmeter/testutils.py
+++ b/plantmeter/testutils.py
@@ -6,6 +6,7 @@ from yamlns import namespace as ns
 # Readable verbose testcase listing
 unittest.TestCase.__str__ = unittest.TestCase.id
 
+
 def assertNsEqual(self, dict1, dict2):
     """
     Asserts that both dict have equivalent structure.
@@ -22,8 +23,8 @@ def assertNsEqual(self, dict1, dict2):
         if type(d) in (dict, ns):
             return ns(sorted(
                 (k, sorteddict(v))
-                for k,v in d.items()
-                ))
+                for k, v in d.items()
+            ))
         if type(d) in (list, tuple):
             return [sorteddict(x) for x in d]
         return d
@@ -32,23 +33,17 @@ def assertNsEqual(self, dict1, dict2):
 
     return self.assertMultiLineEqual(dict1.dump(), dict2.dump())
 
-def _inProduction():
-    import erppeek_wst
-    import dbconfig
-    c = erppeek_wst.ClientWST(**dbconfig.erppeek)
-    c.begin()
-    destructive_testing_allowed = c._execute(
-        'res.config', 'get', 'destructive_testing_allowed', False)
-    c.rollback()
-    c.close()
 
-    if destructive_testing_allowed: return False
-    return True
+def _inProduction():
+    import socket
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    return 'somenergia' in socket.gethostbyaddr(s.getsockname()[0])[0].split('.')
+
 
 def destructiveTest(decorated):
     return unittest.skipIf(_inProduction(),
-        "Destructive test being run in a production setup!!")(decorated)
-
+                           "Destructive test being run in a production setup!!")(decorated)
 
 
 # vim: ts=4 sw=4 et

--- a/som_plantmeter/tests/__init__.py
+++ b/som_plantmeter/tests/__init__.py
@@ -1,0 +1,1 @@
+from plantmeter_test import *

--- a/som_plantmeter/tests/plantmeter_test.py
+++ b/som_plantmeter/tests/plantmeter_test.py
@@ -2,68 +2,69 @@
 # -*- coding: utf-8 -*-
 
 import os
-import datetime
-import pytz
-from plantmeter.mongotimecurve import MongoTimeCurve
-from somutils.isodates import naiveisodate, localisodate, parseLocalTime, asUtc
+from datetime import datetime, timedelta
+from somutils.isodates import localisodate, parseLocalTime, asUtc
 from plantmeter.testutils import destructiveTest
 from yamlns import namespace as ns
+from destral import testing
+from destral.transaction import Transaction
+import tempfile
 
-import unittest
 
 def localTime(string):
     isSummer = string.endswith("S")
-    if isSummer: string=string[:-1]
+    if isSummer:
+        string = string[:-1]
     return parseLocalTime(string, isSummer)
 
+
 def datespan(startDate, endDate):
-    delta=datetime.timedelta(hours=1)
+    delta = timedelta(hours=1)
     currentDate = startDate
     while currentDate < endDate:
         yield currentDate
         currentDate += delta
 
-class PlantShareProvider_Test(unittest.TestCase):
+
+class PlantShareProvider_Test(testing.OOTestCase):
     def setUp(self):
-        import erppeek_wst
-        import dbconfig
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
 
         self.maxDiff = None
-
-        self.c = erppeek_wst.ClientWST(**dbconfig.erppeek)
-        self.c.begin()
-        self.Mix = self.c.GenerationkwhProductionAggregator
-        self.Plant = self.c.GenerationkwhProductionPlant
-        self.Meter = self.c.GenerationkwhProductionMeter
-        self.helper = self.c.GenerationkwhProductionAggregatorTesthelper
+        self.Mix = self.openerp.pool.get('generationkwh.production.aggregator')
+        self.Plant = self.openerp.pool.get('generationkwh.production.plant')
+        self.Meter = self.openerp.pool.get('generationkwh.production.meter')
+        self.helper = self.openerp.pool.get(
+            'generationkwh.production.aggregator.testhelper')
 
     def tearDown(self):
-        self.c.rollback()
-        self.c.close()
+        self.txn.stop()
 
     from plantmeter.testutils import assertNsEqual
 
     def setupMix(self, name, plants=[], description=None, enabled=True):
 
-        mix_id = self.Mix.create(dict(
+        mix_id = self.Mix.create(self.cursor, self.uid, dict(
             name=name,
             description=description or name+' description',
             enabled=enabled,
-            ))
+        ))
 
         return mix_id, [
-            self.Plant.create(dict(
+            self.Plant.create(self.cursor, self.uid, dict(
                 plant,
-                aggr_id = mix_id,
+                aggr_id=mix_id,
                 description=plant['name']+' description',
                 enabled=True,
-                ))
+            ))
             for plantIndex, plant in enumerate(plants)
         ]
 
     def test_items_withZeroPlants(self):
         self.setupMix('testmix', [])
-        items = self.helper.plantShareItems('testmix')
+        items = self.helper.plantShareItems(self.cursor, self.uid, 'testmix')
 
         self.assertNsEqual(ns(items=items), """
             items: []
@@ -79,7 +80,7 @@ class PlantShareProvider_Test(unittest.TestCase):
                 meters=[]
             ),
         ])
-        items = self.helper.plantShareItems('testmix')
+        items = self.helper.plantShareItems(self.cursor, self.uid, 'testmix')
 
         self.assertNsEqual(ns(items=items), """
             items:
@@ -88,7 +89,6 @@ class PlantShareProvider_Test(unittest.TestCase):
               firstEffectiveDate: '2019-03-02'
               lastEffectiveDate: '2019-03-03'
         """)
-
 
     def test_items_withManyPlant(self):
         self.setupMix('testmix', [
@@ -107,7 +107,7 @@ class PlantShareProvider_Test(unittest.TestCase):
                 meters=[]
             ),
         ])
-        items = self.helper.plantShareItems('testmix')
+        items = self.helper.plantShareItems(self.cursor, self.uid, 'testmix')
 
         self.assertNsEqual(ns(items=items), """
             items:
@@ -140,7 +140,7 @@ class PlantShareProvider_Test(unittest.TestCase):
                 meters=[]
             ),
         ])
-        items = self.helper.plantShareItems('testmix')
+        items = self.helper.plantShareItems(self.cursor, self.uid, 'testmix')
 
         self.assertNsEqual(ns(items=items), """
             items:
@@ -151,52 +151,50 @@ class PlantShareProvider_Test(unittest.TestCase):
         """)
 
 
-
 @destructiveTest
-class GenerationkwhProductionAggregator_Test(unittest.TestCase):
+class GenerationkwhProductionAggregator_Test(testing.OOTestCase):
 
     def setUp(self):
-        import erppeek_wst
-        import dbconfig
-        import pymongo
-        import tempfile
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
 
         self.maxDiff = None
-        self.database = 'dummytest'
         self.collection = 'tm_profile'
 
-        self.c = erppeek_wst.ClientWST(**dbconfig.erppeek)
-        self.c.begin()
-        self.helper = self.c.GenerationkwhProductionAggregatorTesthelper
+        self.helper = self.openerp.pool.get(
+            'generationkwh.production.aggregator.testhelper')
+        self.aggr_obj = self.openerp.pool.get(
+            'generationkwh.production.aggregator')
+        self.plant_obj = self.openerp.pool.get(
+            'generationkwh.production.plant')
+        self.meter_obj = self.openerp.pool.get(
+            'generationkwh.production.meter')
         self.tempdir = tempfile.mkdtemp()
         self.clearAggregator()
         self.clearMeasurements()
         self.clearTempContent()
-        
+
     def tearDown(self):
-        self.clear()
-        self.c.rollback()
-        self.c.close()
+        self.txn.stop()
 
     def clear(self):
         self.clearAggregator()
         self.clearMeasurements()
         self.clearTemp()
 
-    
-
     def clearAggregator(self):
-        aggr_obj = self.c.model('generationkwh.production.aggregator')
-        plant_obj = self.c.model('generationkwh.production.plant')
-        meter_obj = self.c.model('generationkwh.production.meter')
-        meter_obj.unlink(meter_obj.search([]))
-        plant_obj.unlink(plant_obj.search([]))
-        aggr_obj.unlink(aggr_obj.search([]))
+        self.meter_obj.unlink(self.cursor, self.uid,
+                              self.meter_obj.search(self.cursor, self.uid, []))
+        self.plant_obj.unlink(self.cursor, self.uid,
+                              self.plant_obj.search(self.cursor, self.uid, []))
+        self.aggr_obj.unlink(self.cursor, self.uid,
+                             self.aggr_obj.search(self.cursor, self.uid, []))
 
     def clearMeasurements(self):
-        self.helper.clear_mongo_collections([
+        self.helper.clear_mongo_collections(self.cursor, self.uid, [
             self.collection,
-            ])
+        ])
 
     def clearTemp(self):
         self.clearTempContent()
@@ -207,22 +205,21 @@ class GenerationkwhProductionAggregator_Test(unittest.TestCase):
             os.remove(os.path.join(self.tempdir, filename))
 
     def setupAggregator(self, nplants, nmeters):
-        aggr_obj = self.c.model('generationkwh.production.aggregator')
-        aggr = aggr_obj.create(dict(
+        aggr_id = self.aggr_obj.create(self.cursor, self.uid, dict(
             name='myaggr',
             description='myaggr',
             enabled=True))
 
         meters = []
         for plant in range(nplants):
-            plant_id = self.setupPlant(aggr, plant)
+            plant_id = self.setupPlant(aggr_id, plant)
             for meter in range(nmeters):
                 meters.append(self.setupMeter(plant_id, plant, meter))
-        return aggr, meters
+        return (self.aggr_obj.browse(self.cursor, self.uid, aggr_id),
+                self.meter_obj.browse(self.cursor, self.uid, meters))
 
     def setupPlant(self, aggr_id, plant):
-        plant_obj = self.c.model('generationkwh.production.plant')
-        return plant_obj.create(dict(
+        return self.plant_obj.create(self.cursor, self.uid, dict(
             aggr_id=aggr_id,
             name='myplant%d' % plant,
             description='myplant%d' % plant,
@@ -231,8 +228,7 @@ class GenerationkwhProductionAggregator_Test(unittest.TestCase):
             nshares=1000*(plant+1)))
 
     def setupMeter(self, plant_id, plant, meter):
-        meter_obj = self.c.model('generationkwh.production.meter')
-        return meter_obj.create(dict(
+        return self.meter_obj.create(self.cursor, self.uid, dict(
             plant_id=plant_id,
             name='mymeter%d%d' % (plant, meter),
             description='mymeter%d%d' % (plant, meter),
@@ -240,142 +236,144 @@ class GenerationkwhProductionAggregator_Test(unittest.TestCase):
             enabled=True))
 
     def setupPointsByDay(self, points):
-
         for meter, start, end, values in points:
             daterange = datespan(
                 localisodate(start),
-                localisodate(end)+datetime.timedelta(days=1)
-                )
+                localisodate(end)+timedelta(days=1)
+            )
             for date, value in zip(daterange, values):
-                self.helper.fillMeasurementPoint(str(asUtc(date))[:-6],meter,value)
+                self.helper.fillMeasurementPoint(self.cursor, self.uid,
+                                                 str(asUtc(date))[:-6], meter, value)
 
     def setupPointsByHour(self, points):
         for meter, date, value in points:
-            self.helper.fillMeasurementPoint(str(asUtc(localTime(date)))[:-6],meter,value)
+            self.helper.fillMeasurementPoint(self.cursor, self.uid,
+                                             str(asUtc(localTime(date)))[:-6], meter, value)
 
     def fillMeter(self, name, points):
         for start, values in points:
-            self.helper.fillMeasurements(start, name, values)
-
+            self.helper.fillMeasurements(
+                self.cursor, self.uid, start, name, values)
 
     def setupLocalMeter(self, filename, points):
-        filename = os.path.join(self.tempdir,filename)
+        filename = os.path.join(self.tempdir, filename)
         import csv
+
         def toStr(date):
             return date.strftime('%Y-%m-%d %H:%M')
 
         with open(filename, 'w') as tmpfile:
             writer = csv.writer(tmpfile, delimiter=';')
             writer.writerows([
-                (toStr(date),summer,value,0,0)
+                (toStr(date), summer, value, 0, 0)
                 for start, end, summer, values in points
-                for date,value in zip(
+                for date, value in zip(
                     datespan(
-                        naiveisodate(start),
-                        naiveisodate(end)+datetime.timedelta(days=1)
+                        datetime.strptime(start, "%Y-%m-%d"),
+                        datetime.strptime(end, "%Y-%m-%d")+timedelta(days=1)
                     ), values)
-                ])
+            ])
 
     def test_get_kwh_onePlant_withNoPoints(self):
         aggr, meters = self.setupAggregator(
-                nplants=1,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
         self.setupPointsByDay([
             ('mymeter00', '2015-08-16', '2015-08-16', 24*[10])
-            ])
-        production = self.helper.get_kwh(
-                aggr_id, '2015-08-17', '2015-08-17')
+        ])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-08-17', '2015-08-17')
         self.assertEqual(production, 25*[0])
 
     def test_get_kwh_onePlant_winter(self):
-        aggr,meters = self.setupAggregator(
-                nplants=1,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
         self.setupPointsByDay([
             ('mymeter00', '2015-03-16', '2015-03-16', 24*[10])
-            ])
-        production = self.helper.get_kwh(
-                aggr_id, '2015-03-16', '2015-03-16')
+        ])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-03-16', '2015-03-16')
         self.assertEqual(production, 24*[10]+[0])
 
     def test_get_kwh_onePlant_winterToSummer(self):
-        aggr,meters = self.setupAggregator(
-                nplants=1,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
         self.setupPointsByHour([
             ('mymeter00', '2015-03-29 00:00:00', 1),
             ('mymeter00', '2015-03-29 01:00:00', 2),
             ('mymeter00', '2015-03-29 03:00:00', 3),
             ('mymeter00', '2015-03-29 23:00:00', 4)
-            ])
-        production = self.helper.get_kwh(
-                aggr_id, '2015-03-29', '2015-03-29')
-        self.assertEqual(production, [1,2,3]+19*[0]+[4,0,0])
+        ])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-03-29', '2015-03-29')
+        self.assertEqual(production, [1, 2, 3]+19*[0]+[4, 0, 0])
 
     def test_get_kwh_onePlant_summer(self):
-        aggr,meters = self.setupAggregator(
-                nplants=1,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
         self.setupPointsByDay([
             ('mymeter00', '2015-08-16', '2015-08-16', 24*[10])
-            ])
-        production = self.helper.get_kwh(
-                aggr_id, '2015-08-16', '2015-08-16')
+        ])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-08-16', '2015-08-16')
         self.assertEqual(production, 24*[10]+[0])
 
     def test_get_kwh_onePlant_summerToWinter(self):
-        aggr,meters = self.setupAggregator(
-                nplants=1,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
         self.setupPointsByHour([
-            ('mymeter00','2015-10-25 00:00:00', 1),
-            ('mymeter00','2015-10-25 02:00:00S', 2),
-            ('mymeter00','2015-10-25 02:00:00', 3),
-            ('mymeter00','2015-10-25 23:00:00', 4)
-            ])
-        production = self.helper.get_kwh(
-                aggr_id, '2015-10-25', '2015-10-25')
-        self.assertEqual(production, [1,0,2,3]+20*[0]+[4])
+            ('mymeter00', '2015-10-25 00:00:00', 1),
+            ('mymeter00', '2015-10-25 02:00:00S', 2),
+            ('mymeter00', '2015-10-25 02:00:00', 3),
+            ('mymeter00', '2015-10-25 23:00:00', 4)
+        ])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-10-25', '2015-10-25')
+        self.assertEqual(production, [1, 0, 2, 3]+20*[0]+[4])
 
     def test_get_kwh_twoPlant_withNoPoints(self):
-        aggr,meters = self.setupAggregator(
-                nplants=2,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=2,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
-        production = self.helper.get_kwh(
-                aggr_id, '2015-08-17', '2015-08-17')
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-08-17', '2015-08-17')
         self.assertEqual(production, 25*[0])
 
     def test_get_kwh_twoPlant_winter(self):
-        aggr,meters = self.setupAggregator(
-                nplants=2,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=2,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
         self.setupPointsByDay([
             ('mymeter00', '2015-03-16', '2015-03-16', 24*[10]),
             ('mymeter10', '2015-03-16', '2015-03-16', 24*[10])
-            ])
-        production = self.helper.get_kwh(
-                aggr_id, '2015-03-16', '2015-03-16')
+        ])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-03-16', '2015-03-16')
         self.assertEqual(production, 24*[20] + [0])
 
     def test_get_kwh_twoPlant_winterToSummer(self):
         aggr, meters = self.setupAggregator(
-                nplants=2,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+            nplants=2,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
         self.setupPointsByHour([
             ('mymeter00', '2015-03-29 00:00:00', 1),
@@ -386,215 +384,214 @@ class GenerationkwhProductionAggregator_Test(unittest.TestCase):
             ('mymeter10', '2015-03-29 01:00:00', 2),
             ('mymeter10', '2015-03-29 03:00:00', 3),
             ('mymeter10', '2015-03-29 23:00:00', 4)
-            ])
-        production = self.helper.get_kwh(
-                aggr_id, '2015-03-29', '2015-03-29')
-        self.assertEqual(production, [2,4,6]+19*[0]+[8,0,0])
+        ])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-03-29', '2015-03-29')
+        self.assertEqual(production, [2, 4, 6]+19*[0]+[8, 0, 0])
 
     def test_get_kwh_twoPlant_summer(self):
-        aggr,meters = self.setupAggregator(
-                nplants=2,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=2,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
         self.setupPointsByDay([
             ('mymeter00', '2015-08-16', '2015-08-16', 24*[10]),
             ('mymeter10', '2015-08-16', '2015-08-16', 24*[10])
-            ])
-        production = self.helper.get_kwh(
-                aggr_id, '2015-08-16', '2015-08-16')
+        ])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-08-16', '2015-08-16')
         self.assertEqual(production, 24*[20]+[0])
 
     def test_get_kwh_twoPlant_summerToWinter(self):
-        aggr,meters = self.setupAggregator(
-                nplants=2,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=2,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
         self.setupPointsByHour([
-            ('mymeter00','2015-10-25 00:00:00', 1),
-            ('mymeter00','2015-10-25 02:00:00S', 2),
-            ('mymeter00','2015-10-25 02:00:00', 3),
-            ('mymeter00','2015-10-25 23:00:00', 4),
-            ('mymeter10','2015-10-25 00:00:00', 1),
-            ('mymeter10','2015-10-25 02:00:00S', 2),
-            ('mymeter10','2015-10-25 02:00:00', 3),
-            ('mymeter10','2015-10-25 23:00:00', 4)
-            ])
-        production = self.helper.get_kwh(
-                aggr_id, '2015-10-25', '2015-10-25')
-        self.assertEqual(production, [2,0,4,6]+20*[0]+[8])
+            ('mymeter00', '2015-10-25 00:00:00', 1),
+            ('mymeter00', '2015-10-25 02:00:00S', 2),
+            ('mymeter00', '2015-10-25 02:00:00', 3),
+            ('mymeter00', '2015-10-25 23:00:00', 4),
+            ('mymeter10', '2015-10-25 00:00:00', 1),
+            ('mymeter10', '2015-10-25 02:00:00S', 2),
+            ('mymeter10', '2015-10-25 02:00:00', 3),
+            ('mymeter10', '2015-10-25 23:00:00', 4)
+        ])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-10-25', '2015-10-25')
+        self.assertEqual(production, [2, 0, 4, 6]+20*[0]+[8])
 
     def test_get_kwh_twoDays(self):
-        aggr,meters = self.setupAggregator(
-                nplants=1,
-                nmeters=1)
-        aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
         self.setupPointsByDay([
             ('mymeter00', '2015-03-16', '2015-03-17', 48*[10])
-            ])
-        production = self.helper.get_kwh(
-                aggr_id, '2015-03-16', '2015-03-17')
+        ])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-03-16', '2015-03-17')
         self.assertEqual(production, 24*[10]+[0]+24*[10]+[0])
 
     def test_fillMeter_withNoPoints(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=1,
-                    nmeters=1)
-            aggr_id = aggr.read(['id'])['id']
-            self.fillMeter('mymeter00',[
-                ])
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
+        self.fillMeter('mymeter00', [
+        ])
 
-            production = self.helper.get_kwh(
-                    aggr_id, '2015-08-16', '2015-08-16')
-            self.assertEqual(production, 25*[0])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-08-16', '2015-08-16')
+        self.assertEqual(production, 25*[0])
 
     def test_fillMeter_onePlant(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=1,
-                    nmeters=1)
-            aggr_id = aggr.read(['id'])['id']
-            self.fillMeter('mymeter00',[
-                ('2015-08-16', 10*[0]+14*[10]),
-                ])
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
+        self.fillMeter('mymeter00', [
+            ('2015-08-16', 10*[0]+14*[10]),
+        ])
 
-            production = self.helper.get_kwh(
-                    aggr_id, '2015-08-16', '2015-08-16')
-            self.assertEqual(production, 10*[0]+14*[10]+[0])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-08-16', '2015-08-16')
+        self.assertEqual(production, 10*[0]+14*[10]+[0])
 
     def test_fillMeter_twoPlant_sameDay(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=2,
-                    nmeters=1)
-            aggr_id = aggr.read(['id'])['id']
-            self.fillMeter('mymeter00',[
-                ('2015-08-16', 10*[0]+14*[10]),
-                ])
-            self.fillMeter('mymeter10',[
-                ('2015-08-16', 10*[0]+14*[20]),
-                ])
+        aggr, meters = self.setupAggregator(
+            nplants=2,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
+        self.fillMeter('mymeter00', [
+            ('2015-08-16', 10*[0]+14*[10]),
+        ])
+        self.fillMeter('mymeter10', [
+            ('2015-08-16', 10*[0]+14*[20]),
+        ])
 
-            production = self.helper.get_kwh(
-                    aggr_id, '2015-08-16', '2015-08-16')
-            self.assertEqual(production, 10*[0]+14*[30]+[0])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-08-16', '2015-08-16')
+        self.assertEqual(production, 10*[0]+14*[30]+[0])
 
     def test_fillMeter_twoPlant_differentDays(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=2,
-                    nmeters=1)
-            aggr_id = aggr.read(['id'])['id']
-            self.fillMeter('mymeter00',[
-                ('2015-08-16', 10*[0]+14*[10]),
-                ])
-            self.fillMeter('mymeter10',[
-                ('2015-08-17', 10*[0]+14*[20]),
-                ])
+        aggr, meters = self.setupAggregator(
+            nplants=2,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
+        self.fillMeter('mymeter00', [
+            ('2015-08-16', 10*[0]+14*[10]),
+        ])
+        self.fillMeter('mymeter10', [
+            ('2015-08-17', 10*[0]+14*[20]),
+        ])
 
-            production = self.helper.get_kwh(
-                    aggr_id, '2015-08-16', '2015-08-17')
-            self.assertEqual(production, 10*[0]+14*[10]+[0]+10*[0]+14*[20]+[0])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-08-16', '2015-08-17')
+        self.assertEqual(production, 10*[0]+14*[10]+[0]+10*[0]+14*[20]+[0])
 
     def test_fillMeter_missing(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=1,
-                    nmeters=1,
-                    )
-            aggr_id = aggr.read(['id'])['id']
-            meter_id = meters[0].read(['id'])['id']
-            self.fillMeter('mymeter00',[
-                ('2015-08-16', 10*[0]+14*[10]),
-                ])
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1,
+        )
+        aggr_id = aggr.read(['id'])[0]['id']
+        meter_id = meters[0].read(['id'])[0]['id']
+        self.fillMeter('mymeter00', [
+            ('2015-08-16', 10*[0]+14*[10]),
+        ])
 
-            production = self.helper.get_kwh(
-                    aggr_id, '2015-08-16', '2015-08-16')
-            self.assertEqual(production, 10*[0]+14*[10]+[0])
+        production = self.helper.get_kwh(self.cursor, self.uid,
+                                         aggr_id, '2015-08-16', '2015-08-16')
+        self.assertEqual(production, 10*[0]+14*[10]+[0])
 
     def test_firstActiveDate_noPlants(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=0,
-                    nmeters=0)
-            aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=0,
+            nmeters=0)
+        aggr_id = aggr.read(['id'])[0]['id']
 
-            date = self.helper.firstActiveDate(aggr_id)
-            self.assertEqual(date, False)
+        date = self.helper.firstActiveDate(self.cursor, self.uid, aggr_id)
+        self.assertEqual(date, None)
 
     def test_firstActiveDate_singlePlant(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=1,
-                    nmeters=1)
-            aggr_id = aggr.read(['id'])['id']
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
 
-            date = self.helper.firstActiveDate(aggr_id)
-            self.assertEqual(date, '2000-01-01')
+        date = self.helper.firstActiveDate(self.cursor, self.uid, aggr_id)
+        self.assertEqual(date, '2000-01-01')
 
     def test_firstMeasurementDate_noPoint(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=1,
-                    nmeters=1)
-            aggr_id = aggr.read(['id'])['id']
-            self.fillMeter('mymeter00',[
-                ])
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
+        self.fillMeter('mymeter00', [
+        ])
 
-            date = self.helper.firstMeasurementDate(aggr_id)
-            self.assertEqual(date, False)
+        date = self.helper.firstMeasurementDate(self.cursor, self.uid, aggr_id)
+        self.assertEqual(date, None)
 
     def test_firstMeasurementDate_onePlant(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=1,
-                    nmeters=1)
-            aggr_id = aggr.read(['id'])['id']
-            self.fillMeter('mymeter00',[
-                ('2015-08-16', 10*[0]+14*[10]),
-                ('2015-08-17', 10*[0]+14*[10]),
-                ])
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
+        self.fillMeter('mymeter00', [
+            ('2015-08-16', 10*[0]+14*[10]),
+            ('2015-08-17', 10*[0]+14*[10]),
+        ])
 
-            date = self.helper.firstMeasurementDate(aggr_id)
-            self.assertEqual(date, '2015-08-16')
+        date = self.helper.firstMeasurementDate(self.cursor, self.uid, aggr_id)
+        self.assertEqual(date, '2015-08-16')
 
     def test_firstMeasurementDate_twoPlant(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=2,
-                    nmeters=1)
-            aggr_id = aggr.read(['id'])['id']
-            self.fillMeter('mymeter00',[
-                ('2015-08-16', 10*[0]+14*[10]),
-                ])
-            self.fillMeter('mymeter10',[
-                ('2015-08-17', 10*[0]+14*[20]),
-                ])
+        aggr, meters = self.setupAggregator(
+            nplants=2,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
+        self.fillMeter('mymeter00', [
+            ('2015-08-16', 10*[0]+14*[10]),
+        ])
+        self.fillMeter('mymeter10', [
+            ('2015-08-17', 10*[0]+14*[20]),
+        ])
 
-            date = self.helper.firstMeasurementDate(aggr_id)
-            self.assertEqual(date, '2015-08-16')
+        date = self.helper.firstMeasurementDate(self.cursor, self.uid, aggr_id)
+        self.assertEqual(date, '2015-08-16')
 
     def test_lastMeasurementDate_onePlant(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=1,
-                    nmeters=1)
-            aggr_id = aggr.read(['id'])['id']
-            self.fillMeter('mymeter00',[
-                ('2015-08-16', 10*[0]+14*[10]),
-                ('2015-08-17', 10*[0]+14*[10]),
-                ])
+        aggr, meters = self.setupAggregator(
+            nplants=1,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
+        self.fillMeter('mymeter00', [
+            ('2015-08-16', 10*[0]+14*[10]),
+            ('2015-08-17', 10*[0]+14*[10]),
+        ])
 
-            date = self.helper.lastMeasurementDate(aggr_id)
-            self.assertEqual(date, '2015-08-17')
+        date = self.helper.lastMeasurementDate(self.cursor, self.uid, aggr_id)
+        self.assertEqual(date, '2015-08-17')
 
     def test_lastMeasurementDate_twoPlant(self):
-            aggr,meters = self.setupAggregator(
-                    nplants=2,
-                    nmeters=1)
-            aggr_id = aggr.read(['id'])['id']
-            self.fillMeter('mymeter00',[
-                ('2015-08-16', 10*[0]+14*[10]),
-                ])
-            self.fillMeter('mymeter10',[
-                ('2015-08-17', 10*[0]+14*[20]),
-                ])
+        aggr, meters = self.setupAggregator(
+            nplants=2,
+            nmeters=1)
+        aggr_id = aggr.read(['id'])[0]['id']
+        self.fillMeter('mymeter00', [
+            ('2015-08-16', 10*[0]+14*[10]),
+        ])
+        self.fillMeter('mymeter10', [
+            ('2015-08-17', 10*[0]+14*[20]),
+        ])
 
-            date = self.helper.lastMeasurementDate(aggr_id)
-            self.assertEqual(date, '2015-08-16')
-
+        date = self.helper.lastMeasurementDate(self.cursor, self.uid, aggr_id)
+        self.assertEqual(date, '2015-08-16')
 
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
## Description

som_plantmeter tests never had been passed

## Changes

- Remove **from somutils.isodates import naiveisodatetime** references
- Add tests/__init__.py
- Adapt tests to run using destral
- Use reusable workflow of [openerp_som_addons](https://github.com/Som-Energia/openerp_som_addons/pull/551)
- Also some unwanted format modifications of [openerp_som_addons style conventions](https://github.com/Som-Energia/openerp_som_addons/blob/main/docs/adr/0001-define-code-style.md)
