### PR TITLE
somutils torna a ser compatible amb Python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-somutils==1.8.9;python_version<="2.7.18"
-somutils>1.8.9;python_version>"2.7.18"
+somutils
 pymongo==3.13.0;python_version<="2.7.18"
 pymongo<4.0;python_version>"2.7.18"
 numpy<1.17;python_version<="2.7.18"


### PR DESCRIPTION
## Objectiu
Desfer el hack per poder instal·lar versions diferents de somutils segons versió de python, ja que s'ha publicat nova versió del paquet que restaura la compatibilitat amb Python 2.7 https://github.com/Som-Energia/somenergia-utils/releases/tag/somutils-1.10.0

## Targeta on es demana o Incidència
Xat

## Comportament antic
S'instal·lava la última versió de somutils compatible per python 2.7

## Comportament nou
S'instal·la sempre la última versió de somutils