### PR TITLE
Discard quarterhourly values in curve get

### DIFF
--- a/plantmeter/mongotimecurve.py
+++ b/plantmeter/mongotimecurve.py
@@ -121,7 +121,8 @@ class MongoTimeCurve(object):
             self.timestamp: {
                 '$gte': start,
                 '$lt': addDays(stop,1)
-            }
+            },
+            "type": {"$ne" : "p4"},  # discard quarterhourly values, there are included in type=p
         }
         if isinstance(filter, dict):
             filters.update(filter)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('README.md') as f:
 
 setup(
     name = "plantmeter",
-    version = "1.7.11",
+    version = "1.7.12",
     description =
         "OpenERP module and library to manage multisite energy generation",
     author = "Som Energia SCCL",


### PR DESCRIPTION
Descarta les corves quarthoraries. Amb el negatiu s'assegura que si no existeix el camp type, tampoc filtra res, de manera que només afecta quan existeix un camp type a la colecció i te valor p4, treientles.


